### PR TITLE
PageToken on almost everything

### DIFF
--- a/Absence.yaml
+++ b/Absence.yaml
@@ -47,10 +47,28 @@ Absence:
       required:
         - id
 
+
+
+AbsencesArray:
+    type: array
+    items:
+      $ref: "#/Absence"
+   
+
 Absences:
-  type: array
-  items:
-    $ref: "#/Absence"
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/Absence"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data
+
 
 Error:
   required:

--- a/Activity.yaml
+++ b/Activity.yaml
@@ -153,7 +153,23 @@ Activity:
     - startDate
     - groups
 
+
+
+ActivitiesArray:
+    type: array
+    items:
+      $ref: "#/Activity"
+
 Activities:
-  type: array
-  items:
-    $ref: "#/Activity"
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/Activity"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data

--- a/AggregatedAttendance.yaml
+++ b/AggregatedAttendance.yaml
@@ -48,3 +48,19 @@ AggregatedAttendance:
     - activity
     - student
     - attendanceSum
+
+
+
+AggregatedAttendances:
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/AggregatedAttendance"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data

--- a/Attendance.yaml
+++ b/Attendance.yaml
@@ -48,10 +48,28 @@ Attendance:
       required:
         - meta
 
+
+
+AttendancesArray:
+    type: array
+    items:
+      $ref: "#/Attendance"
+
+
+
 Attendances:
-  type: array
-  items:
-    $ref: "#/Attendance"
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/Attendance"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data
 
 Error:
   required:

--- a/CalendarEvent.yaml
+++ b/CalendarEvent.yaml
@@ -134,3 +134,19 @@ CalendarEvent:
     - endTime
     - meta
     - activity
+
+
+
+CalendarEvents:
+ type: object
+ properties:
+      data:
+        type: array
+        items:
+          $ref: "#/CalendarEvent"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+ required:
+    - data

--- a/ChildCareAttendanceEvent.yaml
+++ b/ChildCareAttendanceEvent.yaml
@@ -52,6 +52,20 @@ ChildCareAttendanceEvent:
             group:
               $ref: "StudentGroup.yaml#/StudentGroup"
 
+ChildCareAttendanceEvents:
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/ChildCareAttendanceEvent"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data
+
 Error:
   required:
     - code

--- a/ChildCareSchedule.yaml
+++ b/ChildCareSchedule.yaml
@@ -92,3 +92,18 @@ Error:
       format: int32
     message:
       type: string
+
+
+ChildCareSchedules:
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/ChildCareSchedule"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data

--- a/Duty.yaml
+++ b/Duty.yaml
@@ -79,7 +79,21 @@ Duty:
                         type: string
                         format: date 
 
+DutiesArray:
+    type: array
+    items:
+      $ref: "#/Duty"
+
 Duties:
-  type: array
-  items:
-    $ref: "#/Duty"
+ type: object
+ properties:
+      data:
+        type: array
+        items:
+          $ref: "#/Duty"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+ required:
+    - data

--- a/Grade.yaml
+++ b/Grade.yaml
@@ -99,8 +99,22 @@ Grade:
     - finalGrade
     - adaptedStudyPlan
 
-        
+GradesArray:
+    type: array
+    items:
+      $ref: "#/Grade"  
+
+
 Grades:
-  type: array
-  items:
-    $ref: "#/Grade"
+ type: object
+ properties:
+      data:
+        type: array
+        items:
+          $ref: "#/Grade"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+ required:
+    - data

--- a/Organisation.yaml
+++ b/Organisation.yaml
@@ -35,3 +35,24 @@ Organisation:
     - displayName
     - organisationType
   description: En skolhuvudman eller annan slags organisatorisk enhet.
+
+OrganisationsArray:
+    type: array
+    items:
+      $ref: "#/Organisation"  
+
+
+
+Organisations:
+ type: object
+ properties:
+      data:
+        type: array
+        items:
+          $ref: "#/Organisation"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+ required:
+    - data

--- a/Person.yaml
+++ b/Person.yaml
@@ -250,6 +250,11 @@ Persons:
   items:
     $ref: "#/Person"
 
+PersonsExpandedArray:
+  type: array
+  items:
+    $ref: "#/PersonExpanded"
+
 PersonsExpanded:
   type: object
   properties:

--- a/Placement.yaml
+++ b/Placement.yaml
@@ -67,7 +67,22 @@ Placement:
             - $ref: "common.yaml#/PersonReference"
             - description: Identifierare av person som placeringen är knuten till.
 
-Placements:
-  type: array
-  items:
+PlacementsArray:
+ type: array
+ items:
     $ref: "#/Placement"
+
+Placements:
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/Placement"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data
+

--- a/Programme.yaml
+++ b/Programme.yaml
@@ -80,7 +80,22 @@ Programme:
     - name
     - schoolType
 
+ProgrammesArray:
+    type: array
+    items:
+      $ref: "#/Programme"
+
 Programmes:
-  type: array
-  items:
-    $ref: "#/Programme"
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/Programme"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data
+

--- a/Resource.yaml
+++ b/Resource.yaml
@@ -23,7 +23,22 @@ Resource:
     - displayName
     - owner
 
+
+ResourcesArray:
+      type: array
+      items:
+        $ref: "#/Resource"
+
 Resources:
-  type: array
-  items:
-    $ref: "#/Resource"
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/Resource"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data

--- a/Room.yaml
+++ b/Room.yaml
@@ -24,7 +24,21 @@ Room:
     - displayName
     - owner
 
+RoomsArray:
+        type: array
+        items:
+          $ref: "#/Room"
+
 Rooms:
-  type: array
-  items:
-    $ref: "#/Room"
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/Room"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data

--- a/SchoolUnit.yaml
+++ b/SchoolUnit.yaml
@@ -69,7 +69,21 @@ SchoolUnit:
     - displayName
     - schoolTypes
 
+SchoolUnitsArray:
+        type: array
+        items:
+          $ref: "#/SchoolUnit"
+
 SchoolUnits:
-  type: array
-  items:
-    $ref: "#/SchoolUnit"
+ type: object
+ properties:
+      data:
+        type: array
+        items:
+          $ref: "#/SchoolUnit"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+ required:
+    - data

--- a/StudentGroup.yaml
+++ b/StudentGroup.yaml
@@ -94,7 +94,22 @@ StudentGroup:
     - startDate
     - schoolUnit
 
+
+StudentGroupsArray:
+        type: array
+        items:
+          $ref: "#/StudentGroup"
+
 StudentGroups:
-  type: array
-  items:
-    $ref: "#/StudentGroup"
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/StudentGroup"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data

--- a/StudyPlan.yaml
+++ b/StudyPlan.yaml
@@ -72,7 +72,20 @@ StudyPlan:
     - startDate
     - lastUpdate
 
+
+
+
+
 StudyPlans:
-  type: array
-  items:
-    $ref: "#/StudyPlan"
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/StudyPlan"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data

--- a/Subscription.yaml
+++ b/Subscription.yaml
@@ -49,10 +49,22 @@ Subscription:
         - expires
     - $ref: "#/CreateSubscription"
 
+
+
+
 Subscriptions:
-  type: array
-  items:
-    $ref: "#/Subscription"
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/Subscription"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data
 
 Error:
   required:

--- a/Syllabus.yaml
+++ b/Syllabus.yaml
@@ -88,7 +88,23 @@ Syllabus:
     - subjectName
     - official
 
+
+SyllabusesArray:
+        type: array
+        items:
+          $ref: "#/Syllabus"
+
+
 Syllabuses:
-  type: array
-  items:
-    $ref: "#/Syllabus"
+  type: object
+  properties:
+      data:
+        type: array
+        items:
+          $ref: "#/Syllabus"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+  required:
+    - data

--- a/paths/absences.yaml
+++ b/paths/absences.yaml
@@ -57,15 +57,21 @@ absences:
             - StartTimeAsc
             - StartTimeDesc
           default: LastModifiedDesc
-      - $ref: "searchParameters.yaml#/Offset"
+     
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
               $ref: "../Absence.yaml#/Absences"
+      400:
+        description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          ,   `expand`,`schoolUnit`, `student`,`registeredBy`,`type`, `startTime.before`, `startTime.after`) kan inte kombineras med `pageToken`
+
   post:
     tags:
       - Närvaro
@@ -99,12 +105,14 @@ AbsenceLookup:
     description: >
       Hämta många anmälda frånvaro.
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../Absence.yaml#/Absence"
+              $ref: "../Absence.yaml#/AbsencesArray"
+      503:
+        description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:

--- a/paths/activities.yaml
+++ b/paths/activities.yaml
@@ -29,15 +29,21 @@ activities:
             enum: [studentGroups]
       - $ref: "searchParameters.yaml#/ExpandReferenceNames"
       - $ref: "searchParameters.yaml#/Sortkey"
-      - $ref: "searchParameters.yaml#/Offset"
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
               $ref: "../Activity.yaml#/Activities"
+      400:
+        description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          ,   `expand`, `person`,`schoolUnit`) kan inte kombineras med `pageToken`
+
+
 
 activitiesLookup:
   post:
@@ -47,12 +53,14 @@ activitiesLookup:
     description: >
       Hämta många aktiviteter.
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../Activity.yaml#/Activities"
+              $ref: "../Activity.yaml#/ActivitiesArray"
+      503:
+        description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:

--- a/paths/aggregatedAttendances.yaml
+++ b/paths/aggregatedAttendances.yaml
@@ -48,6 +48,8 @@ get:
           type: string
           enum: [ activity, student ]
     - $ref: "searchParameters.yaml#/ExpandReferenceNames"
+    - $ref: "searchParameters.yaml#/Limit"
+    - $ref: "searchParameters.yaml#/PageToken"
 
   responses:
     200:
@@ -55,6 +57,8 @@ get:
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: "../AggregatedAttendance.yaml#/AggregatedAttendance"
+              $ref: "../AggregatedAttendance.yaml#/AggregatedAttendances"
+    400:
+        description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          ,   `expand`, `startDate`,`endDate`,`schoolUnit`,`schoolType`, `student`) kan inte kombineras med `pageToken`

--- a/paths/attendances.yaml
+++ b/paths/attendances.yaml
@@ -9,15 +9,20 @@ attendances:
       - $ref: "searchParameters.yaml#/SearchModifiedBefore"
       - $ref: "searchParameters.yaml#/SearchModifiedAfter"
       - $ref: "searchParameters.yaml#/ExpandReferenceNames"
-      - $ref: "searchParameters.yaml#/Offset"
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
               $ref: "../Attendance.yaml#/Attendances"
+      400:
+        description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          ,   `expand`) kan inte kombineras med `pageToken`
+
   post:
     tags:
       - Närvaro
@@ -51,12 +56,14 @@ attendancesLookup:
     description: >
       Hämta många närvaro.
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../Attendance.yaml#/Attendances"
+              $ref: "../Attendance.yaml#/AttendancesArray"
+      503:
+        description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:

--- a/paths/calendarEvents.yaml
+++ b/paths/calendarEvents.yaml
@@ -47,17 +47,21 @@ calendarEvents:
             type: string
             enum: [  activity, attendance ]           
       - $ref: "searchParameters.yaml#/ExpandReferenceNames"  
-      - $ref: "searchParameters.yaml#/Offset"
+     
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: "../CalendarEvent.yaml#/CalendarEvent"
+                $ref: "../CalendarEvent.yaml#/CalendarEvents"
+      400:
+        description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          ,   `expand`,`startTime`, `endTime`, `activity`,`student`) kan inte kombineras med `pageToken`
+
 
 calendarEventById: 
   get:

--- a/paths/childCareAttendanceEvents.yaml
+++ b/paths/childCareAttendanceEvents.yaml
@@ -26,7 +26,7 @@ attendance_events:
       - $ref: "searchParameters.yaml#/SearchModifiedBefore"
       - $ref: "searchParameters.yaml#/SearchModifiedAfter"
       - name: expand
-        description: Beskriver om expanderade data ska hämtas för aktiviteten.
+        description: Beskriver om expanderade data ska hämtas för in-/utcheckningar.
         in: query
         schema:
           type: array
@@ -34,17 +34,21 @@ attendance_events:
             type: string
             enum: [child, group, registeredBy]
       - $ref: "searchParameters.yaml#/ExpandReferenceNames"
-      - $ref: "searchParameters.yaml#/Offset"
+    
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: "../ChildCareAttendanceEvent.yaml#/ChildCareAttendanceEvent"
+                $ref: "../ChildCareAttendanceEvent.yaml#/ChildCareAttendanceEvents"
+      400:
+        description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          ,   `expand`,`group`, `child`) kan inte kombineras med `pageToken`
+
   post:
     tags:
       - Närvarohändelser

--- a/paths/childcareSchedules.yaml
+++ b/paths/childcareSchedules.yaml
@@ -34,17 +34,22 @@ childcare_schedules:
             type: string
             enum: [ child, group ]
       - $ref: "searchParameters.yaml#/ExpandReferenceNames"
-      - $ref: "searchParameters.yaml#/Offset"
+      
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: "../ChildCareSchedule.yaml#/ChildCareSchedule"
+                $ref: "../ChildCareSchedule.yaml#/ChildCareSchedules"
+      400:
+        description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          ,   `expand`, `child`,`group`) kan inte kombineras med `pageToken`
+
+
   post:
     tags:
       - Barnomsorgsschema

--- a/paths/deletedEntities.yaml
+++ b/paths/deletedEntities.yaml
@@ -1,3 +1,5 @@
+
+
 get:
   tags:
     - Verktyg
@@ -33,12 +35,22 @@ get:
             - SchoolUnitGroup
             - SchoolUnitOffering
             - Syllabus
+    - $ref: "searchParameters.yaml#/Limit"
+    - $ref: "searchParameters.yaml#/PageToken"
   responses:
-    "200":
+    200:
       description: successful operation
       content:
         application/json:
           schema:
+            $ref: "#/DeletedEntities"
+    400:
+        description: >
+          Filter (ex `after`, `entity`) kan inte kombineras med `pageToken`
+
+
+
+DeletedEntity:
             type: object
             properties:
               Activity:
@@ -131,3 +143,18 @@ get:
                 items:
                   type: string
                   format: uuid
+
+
+DeletedEntities:
+ type: object
+ properties:
+      data:
+        type: array
+        items:
+          $ref: "#/DeletedEntity"
+      pageToken:
+        type: string
+        nullable: true
+        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+ required:
+    - data

--- a/paths/duties.yaml
+++ b/paths/duties.yaml
@@ -52,15 +52,20 @@ duties:
             - StartDateAsc
             - LastModifiedDesc
           default: LastModifiedDesc
-      - $ref: "searchParameters.yaml#/Offset"
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
               $ref: "../Duty.yaml#/Duties"
+      400:
+        description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          ,`expand`, `dutySchoolUnit`,`dutyRole`, `person`) kan inte kombineras med `pageToken`
+
 
 dutiesLookup:
   post:
@@ -70,12 +75,14 @@ dutiesLookup:
     description: >
       Hämta många tjänstgöringar.
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../Duty.yaml#/Duties"
+              $ref: "../Duty.yaml#/DutiesArray"
+      503:
+        description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:

--- a/paths/grades.yaml
+++ b/paths/grades.yaml
@@ -54,15 +54,21 @@ grades:
             - Student
             - LastModifiedDesc
           default: LastModifiedDesc
-      - $ref: "searchParameters.yaml#/Offset"
+   
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
               $ref: "../Grade.yaml#/Grades"
+      400:
+        description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          ,`expand`, `schoolUnit`,`student`, `registeredBy`,`gradingTeacher`,`registeredDate.onOrAfter`, `registeredDate.onOrBefore`) kan inte kombineras med `pageToken`
+
 gradesLookup:
   post:
     tags:
@@ -71,12 +77,14 @@ gradesLookup:
     description: >
       Hämta många betyg.
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../Grade.yaml#/Grade"
+              $ref: "../Grade.yaml#/GradesArray"
+      503:
+        description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:

--- a/paths/organisations.yaml
+++ b/paths/organisations.yaml
@@ -40,15 +40,20 @@ organisations:
             - DisplayName
             - LastModifiedDesc
           default: LastModifiedDesc
-      - $ref: "searchParameters.yaml#/Offset"
+      
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../Organisation.yaml#/Organisation"
+              $ref: "../Organisation.yaml#/Organisations"
+      400:
+       description: >
+        Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+        , `expand`, `parent`, `type`) kan inte kombineras med `pageToken`
 
 organisationsLookup:
   post:
@@ -58,12 +63,14 @@ organisationsLookup:
     description: >
       Hämta många program.
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../Organisation.yaml#/Organisation"
+              $ref: "../Organisation.yaml#/OrganisationsArray"
+      503:
+        description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:

--- a/paths/persons.yaml
+++ b/paths/persons.yaml
@@ -92,7 +92,7 @@ persons:
       - $ref: "searchParameters.yaml#/Limit"
       - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
@@ -112,12 +112,14 @@ personsLookup:
     description: >
       Hämta många personer.
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../Person.yaml#/PersonsExpanded"
+              $ref: "../Person.yaml#/PersonsExpandedArray"
+      503:
+        description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:

--- a/paths/placements.yaml
+++ b/paths/placements.yaml
@@ -19,8 +19,6 @@ placements:
             - StartDateAsc 
             - LastModifiedDesc
           default: LastModifiedDesc
-      - $ref: "searchParameters.yaml#/Offset"
-      - $ref: "searchParameters.yaml#/Limit"
       - name: schoolUnit
         description: >
           Begränsa urvalet till de barn som har en placering  på angiven
@@ -54,15 +52,22 @@ placements:
           items:
             type: string
             enum: [ child ]
+     
       - $ref: "searchParameters.yaml#/ExpandReferenceNames"
-
+      - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../Placement.yaml#/Placement"
+              $ref: "../Placement.yaml#/Placements"
+      400:
+       description: >
+        Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+         `expand`, `schoolUnit`, `startDate.onOrAfter`,`endDate.onOrBefore`) kan inte kombineras med `pageToken`
+
 
 placementsLookup:
   post:
@@ -72,12 +77,14 @@ placementsLookup:
     description: >
       Hämta många placeringar.
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../Placement.yaml#/Placement"
+              $ref: "../Placement.yaml#/PlacementsArray"
+      503:
+        description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:

--- a/paths/programmes.yaml
+++ b/paths/programmes.yaml
@@ -32,15 +32,20 @@ programmes:
             - Code
             - LastModifiedDesc
           default: LastModifiedDesc
-      - $ref: "searchParameters.yaml#/Offset"
+      
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
               $ref: "../Programme.yaml#/Programmes"
+      400:
+       description: >
+        Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+         , `expand`, `schoolType`, `code` ) kan inte kombineras med `pageToken`
 
 programmesLookup:
   post:
@@ -50,12 +55,14 @@ programmesLookup:
     description: >
       Hämta många program.
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../Programme.yaml#/Programmes"
+              $ref: "../Programme.yaml#/ProgrammesArray"
+      503:
+        description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:

--- a/paths/resources.yaml
+++ b/paths/resources.yaml
@@ -24,15 +24,19 @@ resources:
             - DisplayName
             - LastModifiedDesc
           default: LastModifiedDesc
-      - $ref: "searchParameters.yaml#/Offset"
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
               $ref: "../Resource.yaml#/Resources"
+      400:
+        description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          ,   `expand`, `owner`) kan inte kombineras med `pageToken`
 
 resourcesLookup:
   post:
@@ -42,12 +46,14 @@ resourcesLookup:
     description: >
       Hämta många program.
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../Resource.yaml#/Resources"
+              $ref: "../Resource.yaml#/ResourcesArray"
+      503:
+        description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:

--- a/paths/rooms.yaml
+++ b/paths/rooms.yaml
@@ -24,15 +24,21 @@ rooms:
             - DisplayName
             - LastModifiedDesc
           default: LastModifiedDesc
-      - $ref: "searchParameters.yaml#/Offset"
+    
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
               $ref: "../Room.yaml#/Rooms"
+      400:
+        description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          ,   `expand`, `owner`) kan inte kombineras med `pageToken`
+
 
 roomsLookup:
   post:
@@ -42,12 +48,14 @@ roomsLookup:
     description: >
       Hämta många program.
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../Room.yaml#/Rooms"
+              $ref: "../Room.yaml#/RoomsArray"
+      503:
+        description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:

--- a/paths/schoolUnits.yaml
+++ b/paths/schoolUnits.yaml
@@ -55,15 +55,20 @@ schoolUnits:
             - DisplayName
             - LastModifiedDesc
           default: LastModifiedDesc
-      - $ref: "searchParameters.yaml#/Offset"
+     
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
               $ref: "../SchoolUnit.yaml#/SchoolUnits"
+      400:
+        description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          ,   `expand`, `organisation`,`municipalityCode`, `schoolTypes`,`startDate.onOrAfter`, `endDate.onOrBefore`) kan inte kombineras med `pageToken`
 
 schoolUnitsLookup:
   post:
@@ -73,12 +78,14 @@ schoolUnitsLookup:
     description: >
       Hämta många skolenheter.
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../SchoolUnit.yaml#/SchoolUnits"
+              $ref: "../SchoolUnit.yaml#/SchoolUnitsArray"
+      503:
+        description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:

--- a/paths/searchParameters.yaml
+++ b/paths/searchParameters.yaml
@@ -81,4 +81,4 @@ Limit:
   required: false
   description: >
     Antal poster som ska visas i resultatet.
-    Utelämnas det så returnas samtliga poster utan begränsning.
+    Utelämnas det så returnas så många poster som möjligt av servern, se `pageToken`.

--- a/paths/studentGroups.yaml
+++ b/paths/studentGroups.yaml
@@ -72,15 +72,21 @@ studentGroups:
             - EndDateAsc
             - EndDateDesc
           default: LastModifiedDesc
-      - $ref: "searchParameters.yaml#/Offset"
+   
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
               $ref: "../StudentGroup.yaml#/StudentGroups"
+      400:
+        description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          ,   `expand`, `studentGroupType`,`schoolTypes`, `owner`,`startDate.onOrAfter`, `endDate.onOrBefore`) kan inte kombineras med `pageToken`
+
 
 studentGroupsLookup:
   post:
@@ -90,12 +96,14 @@ studentGroupsLookup:
     description: >
       Hämta många program.
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
-              $ref: "../StudentGroup.yaml#/StudentGroups"
+              $ref: "../StudentGroup.yaml#/StudentGroupsArray"
+      503:
+        description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:

--- a/paths/studyPlans.yaml
+++ b/paths/studyPlans.yaml
@@ -54,12 +54,17 @@ studyPlans:
             - EndDateAsc
             - EndDateDesc
           default: LastUpdateDesc
-      - $ref: "searchParameters.yaml#/Offset"
+    
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
               $ref: "../StudyPlan.yaml#/StudyPlans"
+      400:
+         description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          , `expand`, `student`, `startDate.onOrAfter` , `endDate.onOrBefore`, `lastUpdate.before`) kan inte kombineras med `pageToken`

--- a/paths/subscriptions.yaml
+++ b/paths/subscriptions.yaml
@@ -4,8 +4,11 @@ subscriptions:
       - Prenumeration
       - Verktyg
     summary: Hämta en lista av prenumerationer.
+    parameters:
+      - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken" 
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:

--- a/paths/syllabuses.yaml
+++ b/paths/syllabuses.yaml
@@ -27,15 +27,21 @@ syllabuses:
             - SubjectDesignationAsc
             - SubjectDesignationDesc
           default: LastModifiedDesc
-      - $ref: "searchParameters.yaml#/Offset"
+     
       - $ref: "searchParameters.yaml#/Limit"
+      - $ref: "searchParameters.yaml#/PageToken"
     responses:
-      "200":
+      200:
         description: successful operation
         content:
           application/json:
             schema:
               $ref: "../Syllabus.yaml#/Syllabuses"
+      400:
+         description: >
+          Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
+          , `expand`) kan inte kombineras med `pageToken`
+
 
 syllabusesLookup:
   post:
@@ -45,12 +51,14 @@ syllabusesLookup:
     description: >
       Hämta många syllabuses.
     responses:
-      "200":
-        description: successful operation
-        content:
-          application/json:
-            schema:
-              $ref: "../Syllabus.yaml#/Syllabuses"
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "../Syllabus.yaml#/SyllabusesArray"
+        503:
+          description: The response is too large for the server ie overload
     requestBody:
       content:
         application/json:


### PR DESCRIPTION
Nästan alla GET endpoints har nu pageToken.

De som har /lookup får helt enkelt kasta en 503 om det skulle bli för mycket för servern att hantera.

SchoolUnitOffering är fortfarande så konstig så den har jag inte brytt mig om.