### PR TITLE
Massive update!

### DIFF
--- a/Absence.yaml
+++ b/Absence.yaml
@@ -1,7 +1,8 @@
 AbsenceFragment:
+  title: Absence
   type: object
   description: >
-    Ledighetsansökan med bekräftelse.
+   Absence ska användas för att beskriva anmäld frånvaro för en elev. Den anmälda frånvaron kan avse en av skolan beviljad ledighet eller en frånvaro av annan art som anmäls av eleven själv eller elevens vårdnadshavare.
   properties:
     startTime:
       type: string

--- a/Activity.yaml
+++ b/Activity.yaml
@@ -1,4 +1,5 @@
 Activity:
+  title: Activity
   type: object
   properties:
     id:
@@ -21,19 +22,16 @@ Activity:
     startDate:
       type: string
       format: date
-      description: >
-        Datum för när aktiviteten startar (ISO8601 format,
-        t.ex. "2016-10-15")
-
+      description: Datum för när aktiviteten startar.
+    
     endDate:
       type: string
       format: date
-      description: >
-        Datum för när aktiviteten slutar (ISO8601 format,
-        t.ex. "2016-10-15".
+      description: Datum för när aktiviteten slutar.
 
     activityType:
       type: string
+      title: Code_ActivityType
       enum:
         - Undervisning
         - Elevaktivitet
@@ -43,9 +41,6 @@ Activity:
         - Övrigt
       description: |
         Beskriver vilken typ av aktivitet som avses.
-        - Värde
-
-            Beskrivning
         - Undervisning
 
             Schemalagd tid med koppling till timplan, som ska närvarorapporteras.
@@ -71,25 +66,14 @@ Activity:
       type: array
       minItems: 1
       items:
-        type: object
-        properties:
-          id:
-            type: string
-            format: uuid
-          displayName:
-            type: string
-          startDate:
-            type: string
-            format: date
-          endDate:
-            type: string
-            format: date
+        $ref: "common.yaml#/StudentGroupReference"
       description: De grupper som är kopplade till aktiviteten.
 
     teachers:
       type: array
       items:
         type: object
+        title: DutyAssignment
         properties:
           id:
             type: string
@@ -112,38 +96,19 @@ Activity:
       description: De lärare (Duty-objekt) som är kopplade till aktiviteten.
 
     syllabus:
-      type: object
-      properties:
-        id:
-          type: string
-          format: uuid
-        displayName:
-          type: string
-          description: Beskrivning av ämnesplanen
-      description: Det kurs- eller ämnesplan som aktiviteten är knuten till.
+      allOf: 
+        - $ref: "common.yaml#/SyllabusReference"
+        - description: Det kurs- eller ämnesplan som aktiviteten är knuten till.
 
     schoolUnit:
-      type: object
-      properties:
-        id:
-          type: string
-          format: uuid
-        displayName:
-          type: string
-          description: Ett läsbart namn för att identifiera skolenheten.
-      description: Den skolenhet som aktiviteten är knuten till.
+      allOf: 
+       - $ref: "common.yaml#/SchoolUnitReference"
+       - description: Den skolenhet som aktiviteten är knuten till.
 
     parentActivity:
-      type: object
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: Identifierare för den ursprungliga aktiviteten.
-        displayName:
-          type: string
-          description: Ett läsbart namn för att identifiera aktiviteten.
-      description: Möjlighet att koppla aktiviteten till en ursprunglig "föräldraaktivitet"
+      allOf: 
+       - $ref: "common.yaml#/ActivityReference"
+       - description: Möjlighet att koppla aktiviteten till en eller flera ursprungliga “föräldraaktiviteter”.
 
   required:
     - id

--- a/AggregatedAttendance.yaml
+++ b/AggregatedAttendance.yaml
@@ -1,14 +1,13 @@
 AggregatedAttendance:
   type: object
+  title: AggregatedAttendance
   properties:
     activity:
-      allOf:
-      - $ref: "common.yaml#/ObjectReference"
-      - description: Referens till en aktivitet
+     $ref: "common.yaml#/ActivityReference"
     student:
       allOf:
-        - $ref: "common.yaml#/ObjectReference"
-        - description: Referens till en person
+        - $ref: "common.yaml#/PersonReference"
+        - description: Referens till eleven
     startDate:
       type: string
       format: date
@@ -31,10 +30,10 @@ AggregatedAttendance:
       description: Summerad tid i minuter för elevens deltagande i annan skolaktivitet, såsom elevråd, i stället för deltagande på kalenderhändelser
     reportedSum:
       type: integer
-      description: Summan av den rapporterade tiden för elevens kalenderhändelser
+      description: Summerad tid i minuter för alla elevens kalenderhändelser där läraren eller annan personal har markerat lektionen som färdigrapporterad
     offeredSum:
       type: integer
-      description: Summan av den erbjudna tiden minuter för elevens kalenderhändelser
+      description: Summerad tid i minuter för alla kalenderhändelser där eleven har erbjudits möjlighet att närvara
     _embedded:
       type: object
       properties:

--- a/Attendance.yaml
+++ b/Attendance.yaml
@@ -1,27 +1,29 @@
 CreateAttendance:
   type: object
+  title: Attendance
   properties:
     calendarEvent:
-      type: string
-      format: uuid
+      $ref: "common.yaml#/CalendarEventReference"
     student:
-      type: string
-      format: uuid
-      description: Referens till person som närvaron gäller.
-    reportedBy:
-      $ref: "common.yaml#/PersonReference"
+      allOf:
+        - $ref: "common.yaml#/PersonReference"
+        - description: Referens till eleven.
+    reporter:
+      allOf:
+        - $ref: "common.yaml#/PersonReference"
+        - description: Person som rapporterat kalenderhändelsen.
     isReported:
       type: boolean
-      description: Anger om lektionen är explicit rapporterad.
+      description: Anger om lektionen är rapporterad.
     attendanceMinutes:
       type: integer
-      description: Tid i minuter för elevens närvaro på kalenderhändelsen.
+      description: Längd i minuter för elevens närvaro på kalenderhändelsen.
     validAbsenceMinutes:
       type: integer
-      description: Tid i minuter för elevens giltiga frånvaro på kalenderhändelsen.
+      description: Längd i minuter för elevens giltiga frånvaro på kalenderhändelsen.
     invalidAbsenceMinutes:
       type: integer
-      description: Tid i minuter för elevens ogiltiga frånvaro på kalenderhändelsen.
+      description: Längd i minuter för elevens ogiltiga frånvaro på kalenderhändelsen.
     otherAttendanceMinutes:
       type: integer
       description: Tid i  minuter för elevens deltagande i annan skolaktivitet, såsom elevråd, i stället för deltagande på kalenderhändelsen.

--- a/AttendanceEvent.yaml
+++ b/AttendanceEvent.yaml
@@ -1,22 +1,24 @@
-CreateChildCareAttendanceEvent:
+CreateAttendanceEvent:
   type: object
+  title: AttendanceEvent 
   properties:
     time:
       type: string
       format: date-time
     eventType:
       type: string
+      title: Code_AttendanceEventType
       enum:
         - In
         - Ut
+    person:
+      allOf:
+        - $ref: "common.yaml#/PersonReference"
+        - description: Referens till barnet eller eleven
     registeredBy:
       allOf:
-        - $ref: "common.yaml#/ObjectReference"
+        - $ref: "common.yaml#/PersonReference"
         - description: Anger den person som registrat in- respektive utcheckning.
-    child:
-      allOf:
-        - $ref: "common.yaml#/PlacementReference"
-        - description: Referens till barnets placering
     group:
       allOf:
         - $ref: "common.yaml#/StudentGroupReference"
@@ -27,7 +29,7 @@ CreateChildCareAttendanceEvent:
     - child
     - group
 
-ChildCareAttendanceEvent:
+AttendanceEvent:
   allOf:
     - type: object
       properties:
@@ -39,7 +41,7 @@ ChildCareAttendanceEvent:
           $ref: "common.yaml#/Meta"
       required:
         - id
-    - $ref: "#/CreateChildCareAttendanceEvent"
+    - $ref: "#/CreateAttendanceEvent"
     - type: object
       properties:
         _embedded:
@@ -52,13 +54,13 @@ ChildCareAttendanceEvent:
             group:
               $ref: "StudentGroup.yaml#/StudentGroup"
 
-ChildCareAttendanceEvents:
+AttendanceEvents:
   type: object
   properties:
       data:
         type: array
         items:
-          $ref: "#/ChildCareAttendanceEvent"
+          $ref: "#/AttendanceEvent"
       pageToken:
         type: string
         nullable: true

--- a/CalendarEvent.yaml
+++ b/CalendarEvent.yaml
@@ -4,111 +4,96 @@ CalendarEvent:
     id:
       type: string
       format: uuid
-      description: Ett UUID för kalenderhändelsen.
+      description: Identifierare för kalenderhändelsen.
     meta:
       $ref: "common.yaml#/Meta"
     activity:
       allOf:
-        - $ref: 'common.yaml#/ObjectReference'
-        - description: Referens till en aktivitet
+        - $ref: 'common.yaml#/ActivityReference'
+        - description: Den aktivitet kalenderhändelsen är kopplad till
     startTime:
       type: string
       format: date-time
-      description: Kalenderhändelsens starttid med datum och tid (ISO8601 format tex "2015-12-12T10:00:00").
+      description: Kalenderhändelsens starttid med datum och tid.
     endTime:
       type: string
       format: date-time
-      description: Kalenderhändelsens sluttid med datum och tid (ISO8601 format tex "2015-12-12T10:00:00").
+      description: Kalenderhändelsens sluttid med datum och tid.
     cancelled:
       type: boolean
-      description: Inställd används för att ange att en planerad kalenderhändelse inte ska äga rum till följd av en avbokning eller annan tillfällig avvikelse. Förvalt värde är false.
-    teachingLengthStudent:
-      type: integer
-      description: Faktisk undervisningstid, i minuter, för studenter. Tiden kan vara kortare eller längre än tiden för kalenderhändelsen till exempel då en rast ingår i tiden.
+      description: Inställd används för att ange att en planerad kalenderhändelse inte ska äga rum till följd av en avbokning eller annan tillfällig avvikelse. Förvalt värde är False. 
     teachingLengthTeacher:
       type: integer
-      description: Faktisk undervisningstid, i minuter, för lärare. Lärartiden kan vara kortare eller längre än tiden för kalenderhändelsen.
+      description: Faktisk undervisningstid för lärare anges i minuter. Lärartiden kan vara kortare eller längre än tiden för kalenderhändelsen.
+    teachingLengthStudent:
+      type: integer
+      description: Faktisk undervisningstid för elever (och elever ingående i grupper) anges i minuter. Tiden kan vara kortare eller längre än tiden för kalenderhändelsen, till exempel då en rast ingår i tiden. 
     comment:
       type: string
       description: En text med kompletterande information.
     studentExceptions:
       type: array
       items:
-        allOf:
-          - $ref: 'common.yaml#/ObjectReference'
-          - description: Anger avvikelser beträffande elevs deltagande, tid och längd för ett enstaka kalendertillfälle.
-            properties:
-              participates:
-                type: boolean
-                description: Används för att ange om en elev deltar på ett visst kalendertillfälle.
-              startTime:
-                type: string
-                format: date-time
-                description: Starttid för undantaget (ISO8601 format tex "2015-12-12T10:30:00").
-              endTime:
-                type: string
-                format: date-time
-                description: Sluttid för undantaget (ISO8601 format tex "2015-12-12T11:00:00").
-              teachingLength:
-                type: integer
-                description: Undervisningstid i minuter för eleven. Om den ej anges så gäller det som är angivet i, i första hand, CalendarEvent, och annars i Activity.
-            required:
-              - id
-              - participates
+        type: object
+        title: StudentException 
+        description: Anger avvikelser beträffande elevs deltagande, tid och längd för ett enstaka kalendertillfälle.            
+        properties:
+          student:
+            type: string
+            format: uuid
+            description: Referens till en person  
+          participates:
+            type: boolean
+            description: Används för att ange om en elev deltar på ett visst kalendertillfälle.
+          startTime:
+            type: string
+            format: date-time
+            description: Starttid för undantaget (ISO8601 format tex "2015-12-12T10:30:00").
+          endTime:
+            type: string
+            format: date-time
+            description: Sluttid för undantaget (ISO8601 format tex "2015-12-12T11:00:00").
+          teachingLength:
+            type: integer
+            description: Undervisningstid i minuter för eleven. Om den ej anges så gäller det som är angivet i, i första hand, CalendarEvent, och annars i Activity.
+        required:
+          - student
+          - participates
     teacherExceptions:
       type: array
       items:
-        allOf:
-          - $ref: 'common.yaml#/ObjectReference'
-          - description: Anger avvikelser beträffande lärares ansvar, tid och längd för ett enstaka kalendertillfälle.
-            properties:
-              participates:
-                type: boolean
-                description: Används för att ange om en lärare deltar på ett visst kalendertillfälle.
-              startTime:
-                type: string
-                format: date-time
-                description: Starttid för undantaget (ISO8601 format tex "2015-12-12T10:30:00").
-              endTime:
-                type: string
-                format: date-time
-                description: Sluttid för undantaget (ISO8601 format tex "2015-12-12T11:00:00").
-              teachingLength:
-                type: integer
-                description: Undervisningstid i minuter för läraren. Om den ej anges så gäller det som är angivet i, i första hand, CalendarEvent, och annars i Activity.
-            required:
-              - id
-              - participates
-    studentGroupExceptions:
-      type: array
-      items:
-        allOf:
-          - $ref: 'common.yaml#/ObjectReference'
-          - description: Anger avvikelser beträffande elevgruppens deltagande, tid och längd för ett enstaka kalendertillfälle.
-            properties:
-              participates:
-                type: boolean
-                description: Används för att ange om en grupp deltar på ett visst kalendertillfälle.
-              startTime:
-                type: string
-                format: date-time
-                description: Starttid för undantaget (ISO8601 format tex "2015-12-12T10:30:00").
-              endTime:
-                type: string
-                format: date-time
-                description: Sluttid för undantaget (ISO8601 format tex "2015-12-12T11:00:00").
-              teachingLength:
-                type: integer
-                description: Undervisningstid i minuter för gruppen. Om den ej anges så gäller det som är angivet i, i första hand, CalendarEvent, och annars i Activity.
-            required:
-              - id
-              - participates
+        type: object
+        title: TeacherException 
+        description: Anger avvikelser beträffande lärares ansvar, tid och längd för ett enstaka kalendertillfälle.
+        properties:
+          duty:
+            type: string
+            format: uuid
+            description: Anger vilken anställning (Duty) undantaget avser.
+          participates:
+            type: boolean
+            description: Används för att ange om en lärare ska delta på ett visst kalendertillfälle. 
+          startTime:
+            type: string
+            format: date-time
+            description: Starttid för undantaget.
+          endTime:
+            type: string
+            format: date-time
+            description: Sluttid för undantaget.
+          teachingLength:
+            type: integer
+            description: Undervisningstid i minuter för läraren. Om den ej anges så gäller det som är angivet i, i första hand, CalendarEvent, och annars i Activity.
+        required:
+          - duty
+          - participates
     rooms:
         type: array
         items:
           allOf:
             - $ref: 'common.yaml#/ObjectReference'
-            - description: De lokaler eller platser som är bokade för kalenderhändelsen.
+            - title: RoomReference
+              description: Den lokal eller plats som är bokad för kalenderhändelsen.
               required:
                 - id
     resources:
@@ -116,7 +101,8 @@ CalendarEvent:
         items:
           allOf:
             - $ref: 'common.yaml#/ObjectReference'
-            - description: De resurser som är bokade för kalenderhändelsen.
+            - title: ResourceReference
+              description: En bokningsbar resurs som inte är en lokal.
               required:
                 - id
     _embedded:

--- a/ChildCareSchedule.yaml
+++ b/ChildCareSchedule.yaml
@@ -1,21 +1,61 @@
 CreateChildCareSchedule:
   type: object
+  title: ChildCareSchedule
   properties:
-    startDate:
-      type: string
-      format: date
-      description: Startdatum för schemat (ISO8601 format, t.ex. "2016-10-15").
-    endDate:
-      type: string
-      format: date
-      description: Startdatum för schemat (ISO8601 format, t.ex. "2016-10-15").
+    placement:
+      allOf:
+        - $ref: "common.yaml#/PlacementReference"
+        - description: Referens till en placeringen schemat avser.
     numberOfWeeks:
       type: integer
       description: Hur många veckor schemat gäller för innan det "börjar om".
-    scheduleDays:
+    startDate:
+      type: string
+      format: date
+      description: Anger datum då schemat startar.
+    endDate:
+      type: string
+      format: date
+      description: Anger datum då schemat slutar.
+    temporary:
+      type: boolean
+      description: |
+        Anger om detta är ett undantag som gäller i stället för normalschemat under en begränsad tid. 
+        Slutdatum måste anges. 
+      default: false
+    state:
       type: array
       items:
         type: object
+        title: ChildCareScheduleState
+        properties:
+          state:
+            type: string
+            title: Code_ChildCareScheduleState
+            enum:
+              - Godkänt
+              - Begärt
+              - Nekat
+            description: Beskriver schemats tillstånd.
+          registeredAt:
+            type: string
+            format: date-time
+            description: Tid och datum för tillstånd.
+          comment:
+            type: string
+            description: En kommentar angående tillståndet.
+          registeredBy:
+            allOf:
+              - $ref: "common.yaml#/PersonReference"
+              - description: Referens till den person som registrerat tillståndet.
+        required: 
+          - state
+          - registeredAt
+    scheduleEntries:
+      type: array
+      items:
+        type: object
+        title: ChildCareScheduleEntry
         properties:
           weekOffset:
             type: integer
@@ -41,17 +81,6 @@ CreateChildCareSchedule:
           length:
             type: integer
             description: Längden på den tid efter starttid som barnet ska vara
-    state:
-      type: string
-      enum:
-        - Tillfälligt
-        - Begärt
-        - Godkänt
-      description: Beskriver tillståndet på detta schema
-    placement:
-      allOf:
-        - $ref: "common.yaml#/PlacementReference"
-        - description: Referens till barnets placering
     
   required:
     - startDate
@@ -72,15 +101,6 @@ ChildCareSchedule:
       required:
         - id
     - $ref: "#/CreateChildCareSchedule"
-    - type: object
-      properties:
-        _expand:
-          type: object
-          properties:
-            child:
-              $ref: "Person.yaml#/Person"
-            group:
-              $ref: "StudentGroup.yaml#/StudentGroup"
 
 Error:
   required:

--- a/Duty.yaml
+++ b/Duty.yaml
@@ -1,4 +1,6 @@
 DutyFragment:
+  type: object
+  title: Duty
   description: referens till ett Dutyobjekt
   properties:
     id:
@@ -10,15 +12,9 @@ DutyFragment:
         - $ref: "common.yaml#/ObjectReference"
         - description: Identifierare av skolenhet som tjänsten är knuten till.
     dutyRole:
-      type: string
-      enum:
-        - Rektor
-        - Lärare
-        - Förskollärare
-        - Övrig pedagogisk personal
-        - Förskolechef
-        - Annan personal
-      description: Syfte med tjänsten, den roll tjänsen avser, till exempel lärare eller rektor.
+      allOf:
+        - $ref: "common.yaml#/components/schemas/DutyRole"
+        - description: Syfte med tjänsten, den roll tjänsen avser, till exempel lärare eller rektor.
     signature:
       type: string
       description: En signatur för tjänstgöringen exempelvis NJN, JOAN.
@@ -67,15 +63,11 @@ Duty:
                       assignmentRoleType:
                         $ref:  "common.yaml#/components/schemas/AssignmentRoleTypeEnum"
                       startDate:
-                        description: >
-                          Startdatum för tjänstens relation till gruppen
-                          (ISO8601 format, t.ex. "2016-10-15").
+                        description: Startdatum för tjänstens relation till gruppen.
                         type: string
                         format: date
                       endDate:
-                        description: >
-                          Slutdatum för tjänstens relation till gruppen
-                          (ISO8601 format, t.ex. "2016-10-15").
+                        description: Slutdatum för tjänstens relation till gruppen.
                         type: string
                         format: date 
 
@@ -94,6 +86,6 @@ Duties:
       pageToken:
         type: string
         nullable: true
-        description:  Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
+        description: Om värdet är null finns inget mer att hämta på det token som skickades in som query parameter.
  required:
     - data

--- a/Enrolment.yaml
+++ b/Enrolment.yaml
@@ -1,4 +1,5 @@
 Enrolment:
+  title: Enrolment
   type: object
   properties:
     enroledAt:

--- a/Grade.yaml
+++ b/Grade.yaml
@@ -55,12 +55,14 @@ Grade:
     correctionType:
       type: string
       description: Ändringstyp för betyget, om det är ändrat.
+      title: Code_GradeCorrectionType
       enum:
         - Ändring
         - Rättelse
     semester:
       type: string
       description: Om betyget avser höst- eller vårtermin.
+      title: Code_Semester
       enum:
         - HT
         - VT

--- a/Organisation.yaml
+++ b/Organisation.yaml
@@ -1,5 +1,6 @@
 Organisation:
   type: object
+  title: Organisation
   properties:
     id:
       type: string
@@ -11,6 +12,7 @@ Organisation:
       description: Namn på organisationen
     organisationType:
       type: string
+      title: Code_OrganisationType
       description: >
         Typ av organisation
       enum:
@@ -26,7 +28,7 @@ Organisation:
         kommun eller bolag
     parentOrganisation:
       allOf:
-        - $ref: "common.yaml#/ObjectReference"
+        - $ref: "common.yaml#/OrganisationReference"
         - description: >
             Identifierare för en eventellt överliggande organisation.
   required:

--- a/Person.yaml
+++ b/Person.yaml
@@ -43,13 +43,16 @@ Person:
           uniqueItems: true
           items:
             type: object
+            title: EduPersonPrincipalName
             properties:
               value:
                 type: string
-                description: eduPersonPrincipalName
+                description: Identifierare för användaren.
                 format: email
               type:
                 type: string
+                description: Anger för vilket syfte användaridentifieraren har skapats, kan ange en roll eller ett utpekat system.
+                title: Code_EduPersonPrincipalType
                 enum:
                   - Pedagogisk personal
                   - Övrig personal
@@ -91,6 +94,7 @@ Person:
         personStatus:
           type: string
           description: Anger ifall en person har en aktiv status eller en annan status, såsom utvandrad eller avliden.
+          title: Code_PersonStatus
           enum:
             - Aktiv
             - Utvandrad
@@ -101,17 +105,19 @@ Person:
           description: En lista med personens epostadresser
           items:
             type: object
+            title: Email
             properties:
               value:
                 type: string
                 format: email
               type:
                 type: string
+                title: Code_EmailType
                 enum:
-                  - Pedagogisk personal
-                  - Övrig personal
-                  - Elev
-                  - Vårdnadshavare
+                  - Privat
+                  - Skola elev
+                  - Skola personal
+                  - Arbete övrigt
             required:
               - value
         phoneNumbers:
@@ -121,12 +127,14 @@ Person:
             required:
               - number
             type: object
+            title: Phonenumber
             properties:
               value:
                 type: string
                 description: Telefonnumret.
               type:
                 type: string
+                title: Code_PhoneNumberType
                 enum:
                   - Hem
                   - Arbete
@@ -142,6 +150,7 @@ Person:
               type:
                 type: string
                 default: Folkbokföringsadress
+                title: Code_AddressType
                 enum:
                   - Folkbokföringsadress
                   - Vistelseadress
@@ -172,6 +181,7 @@ Person:
           description: Bild på personen.
           items:
             type: object
+            title: Photo
             properties:
               value:
                 type: string
@@ -179,6 +189,7 @@ Person:
                 description: En länk där bildfilen kan hämtas.
               type:
                 type: string
+                title: Code_PhotoType
                 description: Typ av bild.
                 enum:
                   - Photo
@@ -236,10 +247,15 @@ PersonExpanded:
             placements:
               type: array
               description: >
-                En lista med placeringen för personen,
-                används för förskoleverksamhet eller för placering på ex kulturskol
+                En lista med placeringar för personen.
               items:
-                $ref: "Placement.yaml#/PlacementFragment"
+                $ref: "Placement.yaml#/Placement"
+            ownedPlacements:
+              type: array
+              description: >
+                En lista med placeringar där personen är satt som ägare. 
+              items:
+                $ref: "Placement.yaml#/Placement"
             duty:
               type: array
               description: Personens aktuella tjänstgöring

--- a/Placement.yaml
+++ b/Placement.yaml
@@ -1,5 +1,6 @@
-PlacementFragment:
+Placement:
   type: object
+  title: Placement
   properties:
     id:
       type: string
@@ -10,22 +11,27 @@ PlacementFragment:
       type: string
       format: uuid
       description: Identifierare för (för)skolenheten där eleven är placerad.
+    studentGroup:
+      allOf:
+        - $ref: "common.yaml#/StudentGroupReference"
+        - description: Barngrupp eller avdelning knutet till denna placering.
     child:
       allOf:
         - $ref: "common.yaml#/PersonReference"
         - description: Identifierare av person som placeringen avser.
     owners:
       type: array
-      description: En lista med indetifierare för de personer som äger placeringen. Används primärt för att styra vilka som skall kunna se och lägga schema.
+      description: En lista med identifierare för de personer som äger placeringen. Används primärt för att styra vilka som skall kunna se och lägga schema.
       items:
-        type: string
-        format: uuid
+        $ref: "common.yaml#/PersonReference"        
     schoolType:
       type: string
-      description: Skolform, exempelvis FS, FTH.
+      title: Code_SchoolType
+      description: Skolform för placeringen, förskola eller fritidshem
       enum:
         - FS
         - FTH
+        - OPPFTH
     startDate:
       type: string
       format: date
@@ -35,37 +41,17 @@ PlacementFragment:
       format: date
       description: Slutdatum för placeringen.
     reason:
-      type: object
-      properties:
-        code: 
-          type: string
-          description: En kod för att beskriva orsak för placeringen.
-          enum:
-            - Omsorg
-            - Erbjuden tid
-            - Eget behov
-        maxWeeklyScheduleHours:
-          type: integer
-          description: >
-            Maxtid i timmar per vecka som är tillåten för placeringen.
-            Används för att begränsa hur många timmar som får schema
-            läggas per vecka.
-    studentGroup:
-      allOf:
-        - $ref: "common.yaml#/StudentGroupReference"
-        - description: Barngrupp eller avdelning knutet till denna placering.
-
-Placement:
-  allOf:
-    - $ref: "#/PlacementFragment"
-    - type: object
-      properties:
-        meta:
-          $ref: "common.yaml#/Meta"
-        person:
-          allOf:
-            - $ref: "common.yaml#/PersonReference"
-            - description: Identifierare av person som placeringen är knuten till.
+      type: string
+      title: Code_Reason
+      description: En kod för att beskriva orsak för placeringen.
+      enum:
+        - Omsorg
+        - Erbjuden tid
+        - Eget behov    
+    maxWeeklyScheduleHours:
+      type: integer
+      description: Anger maximal schematid per vecka för barnets placering.
+    
 
 PlacementsArray:
  type: array

--- a/Programme.yaml
+++ b/Programme.yaml
@@ -34,24 +34,9 @@ Programme:
         _Yrkesprogram_, _Högskoleförberedande program_, _Intruduktionsprogram_, _Nationellt yrkespaket_, _Regionalt yrkespaket_ eller _Fjärde tekniskt år_.
         För övriga programtyper skall värdet inte vara definierat.
     schoolType:
-      type: string
-      enum:
-        - FS
-        - FSK
-        - FTH
-        - GR
-        - GRS
-        - SP
-        - SAM
-        - GY
-        - GYS
-        - VUX
-        - SUV
-        - YH
-        - FHS
-        - HS
-        - AU
-      description: Skolform för programmet.
+      allOf: 
+       - $ref: "common.yaml#/components/schemas/SchoolTypesEnum"
+       - description: Skolform för programmet.
     code:
       type: string
       description: |

--- a/Programme.yaml
+++ b/Programme.yaml
@@ -13,6 +13,7 @@ Programme:
       description: Program-/inriktningens namn.
     type:
       type: string
+      title: Code_ProgrammeType
       enum:
         - Yrkesprogram
         - Högskoleförberedande program
@@ -53,6 +54,7 @@ Programme:
         properties:
           type:
             type: string
+            title: Code_ProgrammeContentType
             description: Anger ingående kursers relation till programmet, såsom Programgemensamma. Typen _Inriktning_ kan endast anges för program av typen _Programinriktning_.
             enum:
               - Gymnasiegemensamma
@@ -68,8 +70,8 @@ Programme:
             type: array
             items:
               allOf:
+                - $ref: "common.yaml#/SyllabusReference"
                 - description: Lista av ingående kursers kursplaner.
-                - $ref: "common.yaml#/ObjectReference"
   required:
     - name
     - schoolType

--- a/Resource.yaml
+++ b/Resource.yaml
@@ -1,5 +1,6 @@
 Resource:
   type: object
+  title: Resource
   properties:
     id:
       type: string
@@ -15,7 +16,8 @@ Resource:
     owner:
       allOf:
         - $ref: "common.yaml#/ObjectReference"
-        - description: >
+        - title: OrganisationReference
+          description: >
             Möjlighet att ange vilket organisationselement resursen tillhör.
   required:
     - id

--- a/Room.yaml
+++ b/Room.yaml
@@ -1,5 +1,6 @@
 Room:
   type: object
+  title: Room
   description: Ett rum eller en plats som kan bokas i ett skolschema.
   properties:
     id:
@@ -17,7 +18,8 @@ Room:
       type: object
       allOf:
         - $ref: "common.yaml#/ObjectReference"
-        - description: Möjlighet att ange vilket organisationselement resursen tillhör.
+        - title: OrganisationReference
+          description: Möjlighet att ange vilket organisationselement resursen tillhör.
   required:
     - id
     - meta

--- a/SchoolUnit.yaml
+++ b/SchoolUnit.yaml
@@ -1,5 +1,6 @@
 SchoolUnit:
   type: object
+  title: SchoolUnit
   description: >
     En Skolenhet, i förekommande fall med skolenhetskod
     enligt Skolenhetsregistret.
@@ -13,7 +14,8 @@ SchoolUnit:
     organisation:
       allOf:
         - $ref: "common.yaml#/ObjectReference"
-        - description: Organisationstillhörighet.
+        - title: OrganisationReference
+          description: Organisationstillhörighet.
     displayName:
       type: string
       description: Namn för skolenheten.
@@ -28,7 +30,7 @@ SchoolUnit:
       uniqueItems: true
       minItems: 1
       items:
-         - $ref: "common.yaml#/components/schemas/SchoolTypesEnum"
+        $ref: "common.yaml#/components/schemas/SchoolTypesEnum"
     municipalityCode:
       type: string
       description: >

--- a/SchoolUnit.yaml
+++ b/SchoolUnit.yaml
@@ -28,23 +28,7 @@ SchoolUnit:
       uniqueItems: true
       minItems: 1
       items:
-        type: string
-        enum:
-          - FS
-          - FSK
-          - FTH
-          - GR
-          - GRS
-          - SP
-          - SAM
-          - GY
-          - GYS
-          - VUX
-          - SUV
-          - YH
-          - FHS
-          - HS
-          - AU
+         - $ref: "common.yaml#/components/schemas/SchoolTypesEnum"
     municipalityCode:
       type: string
       description: >

--- a/SchoolUnitOffering.yaml
+++ b/SchoolUnitOffering.yaml
@@ -1,6 +1,7 @@
 SchoolUnitOffering:
   type: object
-  description: Ett utbud av kurser/program som erbjuds av en skola.
+  title: SchoolUnitOffering
+  description: Används för att beskriva vilka program, ämnen och kurser en skolenhet erbjuder under ett visst tidsintervall. 
   properties:
     startDate:
       type: string
@@ -17,20 +18,18 @@ SchoolUnitOffering:
         Anges i ISO8601 format, exempelvis "2016-10-15".
     offeredAt:
       allOf:
-       - $ref: "common.yaml#/ObjectReference"
+       - $ref: "common.yaml#/SchoolUnitReference"
        - description: Identifierare för skolenheten (SchoolUnit)
     offeredSyllabuses:
       type: array
       items: 
         allOf:
-          - $ref: "common.yaml#/ObjectReference"
-          - description: Identifierare för kursplaner (Syllabus), innehåller alla ämnen/kurser, även de som också beskrivs genom offeredProgrammes
+          - $ref: "common.yaml#/SyllabusReference"
+          - description: Identifierare för kursplaner (Syllabus), innehåller alla ämnen/kurser, även de som också beskrivs genom offeredProgrammes.
     offeredProgrammes:
       type: array
       items:
-        allOf:
-          - $ref: "common.yaml#/ObjectReference"
-          - description: Identifierare för program (Programme)
+        $ref: "common.yaml#/ProgrammeReference"
   required:
     - offeredSyllabuses
     - offeredAt

--- a/StudentGroup.yaml
+++ b/StudentGroup.yaml
@@ -1,16 +1,21 @@
 StudentGroup:
   type: object
+  title: StudentGroup
+  description: >
+    StudentGroup kan innehålla elever eller bara vara en tom "platshållare" utan medlemmar, 
+    som kan populeras vid ett senare tillfälle. 
+    Notera att gruppens koppling till ämnen/kurser och lärare görs via Aktivitet. 
+    Grupper har olika egenskaper baserat på grupptyp. 
+    Individer kan ha olika roller i relation till en viss grupp. Grupper har specifika egenskaper.
   properties:
     id:
       type: string
       format: uuid
-      description: >
-        En studentgrupp. Innehåller elever eller kan vara en tom "platshållare"
-        utan medlemmar och populeras vid ett senare tillfälle.
+      description: Identifierare för elevgruppen
     meta: 
       $ref: "common.yaml#/Meta"
     displayName:
-      description: Gruppens namn.
+      description: Gruppens benämning.
       type: string
     startDate:
       type: string
@@ -45,17 +50,16 @@ StudentGroup:
         allOf:
           - $ref: "common.yaml#/PersonReference"
           - type: object
+            title: StudentMembership 
             properties:
               startDate:
                 description: >
-                  Startdatum för elevens medlemskap i gruppen, från och med
-                  (ISO8601 format, t.ex. "2016-10-15").
+                  Startdatum för elevens medlemskap i gruppen, från och med.
                 type: string
                 format: date
               endDate:
                 description: >
-                  Slutdatum för elevens medlemskap i gruppen, till och med
-                  (ISO8601 format, t.ex. "2016-10-15").
+                  Slutdatum för elevens medlemskap i gruppen, till och med.
                 type: string
                 format: date
     schoolUnit:
@@ -77,14 +81,12 @@ StudentGroup:
                     $ref:  "common.yaml#/components/schemas/AssignmentRoleTypeEnum"
                   startDate:
                     description: >
-                      Startdatum för tjänstens relation till gruppen
-                      (ISO8601 format, t.ex. "2016-10-15").
+                      Startdatum för tjänstens relation till gruppen.
                     type: string
                     format: date
                   endDate:
                     description: >
-                      Slutdatum för tjänstens relation till gruppen
-                      (ISO8601 format, t.ex. "2016-10-15").
+                      Slutdatum för tjänstens relation till gruppen.
                     type: string
                     format: date
   required:

--- a/StudyPlan.yaml
+++ b/StudyPlan.yaml
@@ -1,20 +1,38 @@
 StudyPlan:
   type: object
+  title: StudyPlan
   description: En elevs studieplan
   properties:
+    id:
+      type: string
+      format: uuid
     student:
       allOf:
         - $ref: "common.yaml#/PersonReference"
-        - description: >
-            Den elev som studieplanen gäller för.
+        - description: Den elev som studieplanen gäller för.
+    meta:
+      $ref: "common.yaml#/Meta"
     content:
       type: array
       items:
         type: object
+        title: StudyPlanContent
         properties:
           title:
             type: string
             description: Anger rubriken i elevens studieplan
+          type: 
+            type: string
+            title: Code_StudyPlanContentType
+            enum:
+              - Gymnasiegemensamma
+              - Programgemensamma
+              - Inriktning
+              - Programfördjupning
+              - Gymnasiearbete
+              - Individuellt val
+              - Borttagna
+              - Utökade
           points:
             type: integer
             description: Anger poängtalet för den aktuella kategorin av kurser
@@ -22,12 +40,16 @@ StudyPlan:
             type: array
             items:
               type: object
+              title: StudyPlanSyllabus
               properties:
-                id:
+                syllabus:
                   type: string
+                  title: SyllabusReference
+                  description: Rererens till en kursplan.
                   format: uuid
                 note:
                   type: string
+                  description: Notering angående kursens status i elevens studieplan
                 startDate:
                   type: string
                   format: date
@@ -38,18 +60,20 @@ StudyPlan:
                   type: integer
                   description: >
                     Planlagda timmar för elevens deltagande i kursen. 
-                    Främst avsedd för studieplaner för vuxenutbildning
+                    Främst avsedd för studieplaner till vuxenutbildning.
               required:
-                - id
+                - syllabus
         required:
           - syllabuses
     notes:
       type: array
       items: 
         type: object
+        title: StudyPlanNotes
         properties:
           type: 
             type: string
+            title: Code_StudyPlanNoteType
             enum:
               - Anteckningar
               - Andra insatser som är gynnsamma för elevens kunskapsutveckling
@@ -64,17 +88,10 @@ StudyPlan:
     endDate:
       type: string
       format: date
-    lastModified:
-      type: string
-      format: date-time
   required:
+    - id
     - student
     - startDate
-    - lastUpdate
-
-
-
-
 
 StudyPlans:
   type: object

--- a/Subscription.yaml
+++ b/Subscription.yaml
@@ -1,8 +1,9 @@
 CreateSubscription:
   type: object
+  title: Subscription
   properties:
     name:
-      description: A description name of the webhook
+      description: A descriptive name of the webhook
       type: string
     target:
       description: the URL that the webhook will post to

--- a/Syllabus.yaml
+++ b/Syllabus.yaml
@@ -1,6 +1,7 @@
 Syllabus:
   description: Används för att referera till en specifik kurskod eller ett ämne med information om årskurs och skolform som avses med undervisningen. För officiella ämnen/kurser anges läroplan.
   type: object
+  title: Syllabus
   properties:
     id:
       type: string
@@ -9,8 +10,7 @@ Syllabus:
       $ref: "common.yaml#/Meta"
     schoolType:
       allOf:
-        - description: >
-            Beskriver vilken skolform kursen eller ämnet hör till.
+        - description: Skolform för undervisningen
         - $ref: "common.yaml#/components/schemas/SchoolTypesEnum"
     subjectCode:
       type: string
@@ -41,26 +41,15 @@ Syllabus:
       type: integer
       description: Antalet poäng för en specifik kurs. Exempelvis 100 poäng.
     curriculum:
-      type: string
-      description: Referens till Skolverkets läroplan om det är en officiell kurs eller ett officiellt ämne. Exempelvis GY2011, LGR11.
-      enum:
-        - Lpfö98
-        - Lgr80
-        - Lpo94
-        - Lgr11
-        - Lgrsär11
-        - Lspec11
-        - Lsam11
-        - Lgy70
-        - Lpf94
-        - Gy11
-        - Gysär13
-        - Lvux12
+      allOf:
+        - $ref: "common.yaml#/components/schemas/CurriculumEnum"
+        - description: Referens till Skolverkets läroplan om det är en officiell kurs eller ett officiellt ämne. Exempelvis GY2011, LGR11.
     languageCode:
       type: string
       description: Språkkod för moderna språk och modersmål. Enligt ISO 639-3.
     specialisationCourseContent:
       type: object
+      title: SpecialisationCourseContent
       description: Beskrivning av innehållet i en specialiseringskurs på gymnasiet.
       properties:
         title:

--- a/common.yaml
+++ b/common.yaml
@@ -1,4 +1,5 @@
 ObjectReference:
+  title: ObjectReference
   type: object
   required:
     - id
@@ -14,6 +15,7 @@ ObjectReference:
         Skall endast retuneras när query parametern `expandReferenceNames` är satt till sann.
     
 Meta:
+  title: Meta
   type: object
   readOnly: true
   properties:
@@ -27,37 +29,62 @@ Meta:
 SchoolUnitReference:
   allOf:
     - $ref: "#/ObjectReference"
-    - description: Referens till skolenhet
+    - title: SchoolUnitReference
+      description: Referens till skolenhet
+
+ProgrammeReference:
+  allOf:
+    - $ref: "common.yaml#/ObjectReference"
+    - description: Identifierare för program (Programme)
+      title: ProgrammeReference
+
+OrganisationReference:
+  allOf:
+    - $ref: "#/ObjectReference"
+    - title: OrganisationReference
+      description: Referens till ett Organisations elemet
 
 ActivityReference:
   allOf:
     - $ref: "#/ObjectReference"
-    - description: Referens till en aktivitet
+    - title: ActivityReference
+      description: Referens till en aktivitet
 
 PersonReference:
   allOf:
     - $ref: "#/ObjectReference"
-    - description: Referens till en person
+    - title: PersonReference
+      description: Referens till en person
 
 PlacementReference:
   allOf:
     - $ref: "#/ObjectReference"
-    - description: Referens till en placering
+    - title: PlacementReference
+      description: Referens till en placering
 
 StudentGroupReference:
   allOf:
     - $ref: "#/ObjectReference"
-    - description: Referens till en elevgrupp
+    - title: StudentGroupReference
+      description: Referens till en elevgrupp
 
 SyllabusReference:
   allOf:
     - $ref: "#/ObjectReference"
-    - description: Referens till en Syllabus
+    - title: SyllabusReference
+      description: Referens till en Syllabus
+ 
+CalendarEventReference:
+  allOf:
+    - $ref: "#/ObjectReference"
+    - title: CalendarEventReference
+      description: Referens till en kalenderhändelse
 
 DateConstrainedObjectReference:
   allOf:
     - $ref: "#/ObjectReference"
     - type: object
+      title: DateConstrainedObjectReference
       required:
         - startDate
         - endDate
@@ -72,6 +99,7 @@ DateConstrainedObjectReference:
 components:
   schemas:
     EndPointsEnum:
+      title: Code_ObjectType
       type: string
       enum:
         - Absence
@@ -92,19 +120,22 @@ components:
         - Syllabus
 
     SchoolTypesEnum:
+      title: Code_SchoolType
       type: string
       enum:
         - FS
-        - FSK
+        - FKLASS
         - FTH
+        - OPPFTH
         - GR
         - GRS
         - SP
         - SAM
         - GY
         - GYS
-        - VUX
-        - SUV
+        - KOMVUX
+        - SARVUX
+        - SFI
         - YH
         - FHS
         - HS
@@ -112,6 +143,7 @@ components:
 
     RelationTypesEnum:
       type: string
+      title: Code_RelationType
       description: |
         Värdeförråd för olika typer av relationer till en elev.
       enum:
@@ -122,12 +154,38 @@ components:
 
     AbsenceEnum:
       type: string
+      title: Code_AbsenceType
       enum:
         - Beviljad ledighet
         - Anmäld frånvaro
+    
+    CurriculumEnum: 
+      type: string
+      title: Code_Curriculum
+      enum:
+        - Lgy70
+        - Lgr80
+        - Lpo94
+        - Lpf94
+        - Lpfö98
+        - GR2000
+        - GY2000
+        - GYSÄR2000
+        - GYVUX2000
+        - GYVUX2001
+        - GYVUX2002
+        - GR2011
+        - GRSÄR2011
+        - SPEC2011
+        - SAM2011
+        - Lvux12
+        - GY2011
+        - GYSÄR2013
+        - VU2013
 
     StudentGroupTypesEnum:
       type: string
+      title: Code_StudentGroupType
       description: |
         Grupptyp anger vad en grupp ska användas till.
         Ett värdeförråd för att indikera anger vilka grupptyper som finns.
@@ -142,8 +200,20 @@ components:
         - Mentor
         - Schema
         - Övrigt
+ 
+    DutyRole:
+      type: string
+      title: Code_DutyRole
+      enum:
+        - Rektor
+        - Lärare
+        - Förskollärare
+        - Övrig pedagogisk personal
+        - Förskolechef
+        - Annan personal
 
     AssignmentRoleTypeEnum:
+      title: Code_AssignmentRole
       type: string
       enum:
         - Mentor

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22,7 +22,7 @@ tags:
     description: Information om kurser, ämnen, program och studieplaner.
   - name: Aktiviteter
     description: Aktiviteter knyter ihop lärare och elever med ämne eller kurs.
-  - name: Schema
+  - name: Kalenderhändelser
     description: Kalenderposter kopplat till aktiviteter
   - name: Rum och resurser
     description: Salar och resurser som kan schemaläggas.
@@ -79,6 +79,8 @@ paths:
     $ref: paths/programmes.yaml#/programmeById
   /studyplans:
     $ref: paths/studyPlans.yaml#/studyPlans
+  /studyplans/{id}:
+    $ref: paths/studyPlans.yaml#/studyPlanById
   /syllabuses:
     $ref: paths/syllabuses.yaml#/syllabuses
   /syllabuses/lookup:
@@ -107,12 +109,16 @@ paths:
     $ref: paths/attendances.yaml#/attendancesLookup
   /attendances/{id}:
     $ref: paths/attendances.yaml#/attendanceById
-  /childCareAttendanceEvents:
-    $ref: paths/childCareAttendanceEvents.yaml#/attendance_events
-  /childCareAttendanceEvents/{id}:
-    $ref: paths/childCareAttendanceEvents.yaml#/attendance_events_by_id
+  /attendanceEvents:
+    $ref: paths/attendanceEvents.yaml#/attendance_events
+  /attendanceEvents/{id}:
+    $ref: paths/attendanceEvents.yaml#/attendance_events_by_id
   /childCareSchedule:
-    $ref: paths/childCareSchedules.yaml#/childcare_schedules
+    $ref: paths/childCareSchedules.yaml#/childCareSchedules
+  /childCareSchedule/{id}:
+    $ref: paths/childCareSchedules.yaml#/childCareSchedulesById
+  /childCareSchedule/lookup:
+    $ref: paths/childCareSchedules.yaml#/childCareSchedulesLookup
   /grades:
     $ref: paths/grades.yaml#/grades
   /grades/lookup:
@@ -175,8 +181,8 @@ components:
       $ref: "CalendarEvent.yaml#/CalendarEvent"
     Attendance:
       $ref: "Attendance.yaml#/Attendance"
-    ChildCareAttendanceEvent:
-      $ref: "ChildCareAttendanceEvent.yaml#/ChildCareAttendanceEvent"
+    AttendanceEvent:
+      $ref: "AttendanceEvent.yaml#/AttendanceEvent"
     ChildCareSchedule:
       $ref: "ChildCareSchedule.yaml#/ChildCareSchedule"
     Absence:

--- a/paths/attendanceEvents.yaml
+++ b/paths/attendanceEvents.yaml
@@ -36,7 +36,7 @@ attendance_events:
         content:
           application/json:
             schema:
-                $ref: "../ChildCareAttendanceEvent.yaml#/ChildCareAttendanceEvents"
+                $ref: "../AttendanceEvent.yaml#/AttendanceEvents"
       400:
         description: >
           Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
@@ -51,7 +51,7 @@ attendance_events:
       content:
         application/json:
           schema:
-            $ref: "../ChildCareAttendanceEvent.yaml#/CreateChildCareAttendanceEvent"
+            $ref: "../AttendanceEvent.yaml#/CreateAttendanceEvent"
 
     responses:
       "200":
@@ -59,13 +59,13 @@ attendance_events:
         content:
           application/json:
             schema:
-              $ref: "../ChildCareAttendanceEvent.yaml#/ChildCareAttendanceEvent"
+              $ref: "../AttendanceEvent.yaml#/AttendanceEvent"
       default:
         description: unexpected error
         content:
           application/json:
             schema:
-              $ref: "../ChildCareAttendanceEvent.yaml#/Error"
+              $ref: "../AttendanceEvent.yaml#/Error"
 
 attendance_events_by_id:
   get:
@@ -88,7 +88,7 @@ attendance_events_by_id:
         content:
           application/json:
             schema:
-              $ref: "../ChildCareAttendanceEvent.yaml#/ChildCareAttendanceEvent"
+              $ref: "../AttendanceEvent.yaml#/AttendanceEvent"
       "204":
         description: Posten borttagen.
       "400":
@@ -102,7 +102,7 @@ attendance_events_by_id:
         content:
           application/json:
             schema:
-              $ref: "../ChildCareAttendanceEvent.yaml#/Error"
+              $ref: "../AttendanceEvent.yaml#/Error"
   delete:
     tags:
       - Närvarohändelser

--- a/paths/childcareSchedules.yaml
+++ b/paths/childcareSchedules.yaml
@@ -1,33 +1,38 @@
-childcare_schedules: 
+childCareSchedules: 
   get: 
     tags:
-      - Schema
-    summary: Returnerar registrerade in-/utcheckningar.
+      - Barnomsorgsschema
+    summary: Returnerar registrerade barnomsorgsschema.
     parameters:
-      - name: child
-        description: Begränsa urvalet till utpekade barns ID.
+      - name: placement
+        description: Begränsa urvalet till scheman för utpekade placeringar.
         in: query
         schema:
           type: array
           items:
             type: string
             format: uuid
-      - name: group
-        description: Begränsa urvalet till utpekade groupers ID.
+      - name: startDate.onOrAfter
+        description: >
+          Begränsa urvalet till barnomsorgsschema som är aktiva inom det 
+          intervall som startar på angivet datum.
         in: query
         schema:
-          type: array
-          items:
-            type: string
-            format: uuid
-     
+          type: string
+          format: date
+      - name: endDate.onOrBefore
+        description: >
+          Begränsa urvalet till barnomsorgsschema som är aktiva inom det 
+          intervall som avslutas på angivet datum.
+        in: query
+        schema:
+          type: string
+          format: date
       - $ref: "searchParameters.yaml#/SearchCreatedBefore"
       - $ref: "searchParameters.yaml#/SearchCreatedAfter"
       - $ref: "searchParameters.yaml#/SearchModifiedBefore"
       - $ref: "searchParameters.yaml#/SearchModifiedAfter"
-      - $ref: "#/ExpandParameter"
       - $ref: "searchParameters.yaml#/ExpandReferenceNames"
-      
       - $ref: "searchParameters.yaml#/Limit"
       - $ref: "searchParameters.yaml#/PageToken"
     responses:
@@ -46,7 +51,7 @@ childcare_schedules:
   post:
     tags:
       - Barnomsorgsschema
-    summary: Registrera en ny närvarohändelse (in-/utcheckning).
+    summary: Registrera ett nytt barnomsorgsschema.
     requestBody:
       required: true
       content:
@@ -68,20 +73,44 @@ childcare_schedules:
             schema:
               $ref: "../ChildCareSchedule.yaml#/Error"
 
-childcare_schedule_by_id:
+childCareSchedulesLookup:
+  post:
+    tags:
+      - Barnomsorgsschema
+    summary: Hämta många barnomsorgsschema baserat på en lista av ID:n.
+    description: >
+      Hämta många barnomsorgsschema.
+    parameters:
+      - $ref: "searchParameters.yaml#/ExpandReferenceNames"
+    responses:
+      200:
+        description: successful operation
+        content:
+          application/json:
+            schema:
+              $ref: "../Activity.yaml#/ActivitiesArray"
+      503:
+        description: The response is too large for the server ie overload
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref : "../common.yaml#/components/schemas/IdLookup"
+      required: true
+
+childCareSchedulesById:
   get:
     tags:
         - Barnomsorgsschema
-    summary: Hämta en närvarohändelse utifrån ID.
+    summary: Hämta ett barnomsorgsschema utifrån ID.
     parameters:
       - name: id
-        description: Hämta en närvarohändelse.
+        description: Id för barnomsorgsschema att hämta.
         in: path
         required: true
         schema:
           type: string
           format: uuid
-      - $ref: "#/ExpandParameter"
       - $ref: "searchParameters.yaml#/ExpandReferenceNames"
     responses:
       "200":
@@ -105,11 +134,11 @@ childcare_schedule_by_id:
   delete:
     tags:
         - Barnomsorgsschema
-    summary: Ta bort en närvarohändelse.
+    summary: Ta bort ett barnomsorgsschema.
     parameters:
       - name: id
         in: path
-        description: ID för närvaro posten som ska tas bort.
+        description: ID för barnomsorgsschema som ska tas bort.
         required: true
         schema:
           type: string
@@ -123,14 +152,3 @@ childcare_schedule_by_id:
         description: Otilläckliga rättigheter.
       "404":
         description: Posten hittades inte.
-
-
-ExpandParameter:
-  name: expand
-  description: Beskriver om expanderade data ska hämtas för aktiviteten.
-  in: query
-  schema:
-    type: array
-    items:
-      type: string
-      enum: [ child, group ]

--- a/paths/deletedEntities.yaml
+++ b/paths/deletedEntities.yaml
@@ -15,25 +15,7 @@ deletedEntities:
         schema:
           type: array
           items:
-            type: string
-            enum:
-              - Activity
-              - AggregatedAttendance
-              - ChildCareAttendanceEvent
-              - CalendarEvent
-              - ChildCareSchedule
-              - Duty
-              - Grade
-              - Absence
-              - Organisation
-              - Person
-              - Programme
-              - Resource
-              - Room
-              - SchoolUnit
-              - SchoolUnitGroup
-              - SchoolUnitOffering
-              - Syllabus
+            $ref:  "../common.yaml#/components/schemas/EndPointsEnum"
       - $ref: "searchParameters.yaml#/Limit"
       - $ref: "searchParameters.yaml#/PageToken"
     responses:
@@ -60,7 +42,7 @@ DeletedEntity:
                 items:
                   type: string
                   format: uuid
-              ChildCareAttendanceEvent:
+              AttendanceEvent:
                 type: array
                 items:
                   type: string

--- a/paths/duties.yaml
+++ b/paths/duties.yaml
@@ -14,14 +14,7 @@ duties:
         description: Begränsta urvalet till de tjänstgöringar som matchar roll
         in: query
         schema:
-          type: string
-          enum:
-            - Rektor
-            - Lärare
-            - Förskollärare
-            - Övrig pedagogisk personal
-            - Förskolechef
-            - Annan personal
+          ref: "common.yaml#/components/schemas/DutyRole"
       - name: person
         description: Begränsa urvalet till de tjänstgöringar som är kopplade till person ID
         in: query

--- a/paths/duties.yaml
+++ b/paths/duties.yaml
@@ -14,7 +14,7 @@ duties:
         description: Begränsta urvalet till de tjänstgöringar som matchar roll
         in: query
         schema:
-          ref: "common.yaml#/components/schemas/DutyRole"
+          $ref: "../common.yaml#/components/schemas/DutyRole"
       - name: person
         description: Begränsa urvalet till de tjänstgöringar som är kopplade till person ID
         in: query

--- a/paths/persons.yaml
+++ b/paths/persons.yaml
@@ -174,4 +174,4 @@ ExpandParameter:
     type: array
     items:
       type: string
-      enum: [duties, children]
+      enum: [duties, responsibleFor, placements, , ownedPlacements]

--- a/paths/placements.yaml
+++ b/paths/placements.yaml
@@ -6,8 +6,17 @@ placements:
     parameters:
       - name: schoolUnit
         description: >
-          Begränsa urvalet till de barn som har en placering  på angiven
+          Begränsa urvalet till de barn som har en placering på angiven
           skolenhet. Detta kan kombineras med startDate.onOrAfter
+          och endDate.onOrBefore för att begränsa till aktiva placeringar.
+        in: query
+        schema:
+          type: string
+          format: uuid
+      - name: studentGroup
+        description: >
+          Begränsa urvalet till de barn som har en placering på angiven grupp. 
+          Detta kan kombineras med startDate.onOrAfter
           och endDate.onOrBefore för att begränsa till aktiva placeringar.
         in: query
         schema:
@@ -29,6 +38,23 @@ placements:
         schema:
           type: string
           format: date
+      - name: child
+        description: >
+          Begränsa urvalet till ett barn. Detta kan kombineras med startDate.onOrAfter
+          och endDate.onOrBefore för att begränsa till aktiva placeringar.
+        in: query
+        schema:
+          type: string
+          format: uuid
+      - name: owner
+        description: >
+          Begränsa urvalet till placeringar med denna ägare. Detta kan kombineras med startDate.onOrAfter
+          och endDate.onOrBefore för att begränsa till aktiva placeringar.
+        in: query
+        schema:
+          type: string
+          format: uuid
+     
       - $ref: "searchParameters.yaml#/SearchCreatedBefore"
       - $ref: "searchParameters.yaml#/SearchCreatedAfter"
       - $ref: "searchParameters.yaml#/SearchModifiedBefore"

--- a/paths/studentGroups.yaml
+++ b/paths/studentGroups.yaml
@@ -133,7 +133,7 @@ studentGroupsById:
       "403":
         description: Not authorised
       "404":
-        description: Duty not found
+        description: StudentGroup not found
 
 ExpandParameter: 
   name: expand

--- a/paths/studyPlans.yaml
+++ b/paths/studyPlans.yaml
@@ -25,18 +25,6 @@ studyPlans:
         schema:
           type: string
           format: date
-      - name: lastUpdate.after
-        description: Endast studieplaner som blivit justerade efter denna tidpunkt (Exkluderande)
-        in: query
-        schema:
-          type: string
-          format: date-time
-      - name: lastUpdate.before
-        description: Endast studieplaner som  blivit justerade innan eller på denna tidpunkt (Inkluderande)
-        in: query
-        schema:
-          type: string
-          format: date-time
       - $ref: "searchParameters.yaml#/SearchCreatedBefore"
       - $ref: "searchParameters.yaml#/SearchCreatedAfter"
       - $ref: "searchParameters.yaml#/SearchModifiedBefore"
@@ -68,3 +56,30 @@ studyPlans:
          description: >
           Filter (ex `sortkey`, `meta.modified.after`, `meta.modified.before`, `meta.created.after`, `meta.created.before`
           , `expand`, `student`, `startDate.onOrAfter` , `endDate.onOrBefore`, `lastUpdate.before`) kan inte kombineras med `pageToken`
+
+studyPlanById:
+  get:
+    tags:
+      - Studieinformation
+    summary: Hämta studieplan baserat på ID
+    parameters:
+      - name: id
+        in: path
+        description: ID för studieplan som ska hämtas
+        required: true
+        schema:
+          type: string
+      - $ref: "searchParameters.yaml#/ExpandReferenceNames"
+    responses:
+      "200":
+        description: successful operation
+        content:
+          application/json:
+            schema:
+              $ref: "../StudyPlan.yaml#/StudyPlan"
+      "400":
+        description: Invalid id supplied
+      "403":
+        description: Not authorised
+      "404":
+        description: StudyPlan not found


### PR DESCRIPTION
# General
- Added title to all Enums
- Added title to all Objects
- Adjusted descriptions to match the word doc (Needs to be double checked, when we feel that the descriptions in word are final) 

# ChildcareSchedule
 - Updated followup changes as a result of moving to placements
 - Removed expands
 - Added GET/DELETE http verbs
 - Added lookup
 - Added a state history

# AttendanceEvent
Renamed ChildCareAttendanceEvent to AttendanceEvent to match word.

# CalendarEvent
 - Removed "studentGroupExceptions"

# Person
 - Fixed email type to align with word.
   Might be wrong, was:
      - Pedagogisk personal
      - Övrig personal
      - Elev
      - Vårdnadshavare
 - Added "ownedPlacements" to expands

# Placement
- Added StudentGroup to placement

# StudyPlan
 - Removed LastModified (Can't we use the meta value instead?)