### PR TITLE
Added direct references to schoolUnits.

### DIFF
--- a/Resource.yaml
+++ b/Resource.yaml
@@ -13,18 +13,19 @@ Resource:
     description:
       type: string
       description: Beskrivning av resursen.
-    owner:
+    organisation:
       allOf:
-        - $ref: "common.yaml#/ObjectReference"
-        - title: OrganisationReference
-          description: >
-            Möjlighet att ange vilket organisationselement resursen tillhör.
+        - $ref: "common.yaml#/OrganisationReference"
+        - description: Möjlighet att ange vilket organisationselement resursen tillhör. Måste anges ifall schoolUnits inte är anvigen.
+    schoolUnits:
+      type: array
+      description: Lista av skolenheter som resursen tillhör. Måste anges ifall organisation inte är anvigen.
+      items: 
+        $ref: "common.yaml#/SchoolUnitReference"     
   required:
     - id
     - meta
     - displayName
-    - owner
-
 
 ResourcesArray:
       type: array

--- a/Room.yaml
+++ b/Room.yaml
@@ -1,7 +1,7 @@
 Room:
   type: object
   title: Room
-  description: Ett rum eller en plats som kan bokas i ett skolschema.
+  description: Ett rum eller en plats som kan bokas i ett skolschema. Organisation eller schoolUnits måste anges. Anges båda värdena tillhör rummet allt under Organisationen samt alla refererade skolenheter.
   properties:
     id:
       type: string
@@ -14,17 +14,19 @@ Room:
     seats:
       type: integer
       description: Antal platser i lokalen.
-    owner:
-      type: object
+    organisation:
       allOf:
-        - $ref: "common.yaml#/ObjectReference"
-        - title: OrganisationReference
-          description: Möjlighet att ange vilket organisationselement resursen tillhör.
+        - $ref: "common.yaml#/OrganisationReference"
+        - description: Möjlighet att ange vilket organisationselement rummet tillhör. Måste anges ifall schoolUnits inte är anvigen.
+    schoolUnits:
+      type: array
+      description: Lista av skolenheter som rummet tillhör. Måste anges ifall organisation inte är anvigen.
+      items: 
+        $ref: "common.yaml#/SchoolUnitReference"        
   required:
     - id
     - meta
     - displayName
-    - owner
 
 RoomsArray:
         type: array


### PR DESCRIPTION
Without being able to target specific schoolunits we need to add a lot of extra organisationElements. 
Ex: 

Östra området
 - Grundskolan A (Skolenhet)
 - En annan grundskola (Skolhenhet)

Storgymnasieskola
 - Gymnasieskola1 (Skolenhet)
 - Gymnasieskola2 (Skolenhet)
 - Gymnasieskola3 (Skolenhet)
 - Gymnasieskola4 (Skolenhet)
 - Gymnasieskola5 (Skolenhet)
 - Gymnasieskola6 (Skolenhet)

### VS : 

Östra området
 - Grundskolan A
   - Grundskolan A (Skolenhet) 
 - En annan grundskola (Skolhenhet)
   - En annan grundskola (Skolhenhet)

Storgymnasieskola
 - Gymnasieskola1
   - Gymnasieskola1 (Skolenhet)
 - Gymnasieskola2
   - Gymnasieskola2 (Skolenhet)
 - Gymnasieskola3
   - Gymnasieskola3 (Skolenhet)
 - Gymnasieskola4
   - Gymnasieskola4 (Skolenhet)
 - Gymnasieskola5
   - Gymnasieskola5 (Skolenhet)
 - Gymnasieskola6
   - Gymnasieskola6 (Skolenhet)