### PR TITLE
Fixed broken reference, removed the default sort value

### DIFF
--- a/Organisation.yaml
+++ b/Organisation.yaml
@@ -109,7 +109,7 @@ Organisations:
       data:
         type: array
         items:
-          $ref: "#/OrganisationExpanded"
+          $ref: "#/Organisation"
       pageToken:
         type: string
         nullable: true

--- a/paths/absences.yaml
+++ b/paths/absences.yaml
@@ -62,8 +62,6 @@ absences:
             - ModifiedDesc
             - StartTimeAsc
             - StartTimeDesc
-          default: ModifiedDesc
-
       - $ref: "searchParameters.yaml#/Limit"
       - $ref: "searchParameters.yaml#/PageToken"
     responses:

--- a/paths/calendarEvents.yaml
+++ b/paths/calendarEvents.yaml
@@ -53,7 +53,6 @@ calendarEvents:
             - ModifiedDesc
             - StartTimeAsc
             - StartTimeDesc
-          default: ModifiedDesc
       - $ref: "searchParameters.yaml#/Limit"
       - $ref: "searchParameters.yaml#/PageToken"
     responses:

--- a/paths/duties.yaml
+++ b/paths/duties.yaml
@@ -68,7 +68,6 @@ duties:
             - StartDateDesc
             - StartDateAsc
             - ModifiedDesc
-          default: ModifiedDesc
       - $ref: "searchParameters.yaml#/Limit"
       - $ref: "searchParameters.yaml#/PageToken"
     responses:

--- a/paths/grades.yaml
+++ b/paths/grades.yaml
@@ -58,8 +58,6 @@ grades:
             - registeredDateAsc
             - registeredDateDesc
             - ModifiedDesc
-          default: ModifiedDesc
-
       - $ref: "searchParameters.yaml#/Limit"
       - $ref: "searchParameters.yaml#/PageToken"
     responses:

--- a/paths/groups.yaml
+++ b/paths/groups.yaml
@@ -79,7 +79,6 @@ groups:
             - StartDateDesc
             - EndDateAsc
             - EndDateDesc
-          default: ModifiedDesc
 
       - $ref: "searchParameters.yaml#/Limit"
       - $ref: "searchParameters.yaml#/PageToken"

--- a/paths/persons.yaml
+++ b/paths/persons.yaml
@@ -153,7 +153,6 @@ persons:
             - FamilyNameAsc
             - civicNo
             - ModifiedDesc
-          default: ModifiedDesc
       - $ref: "searchParameters.yaml#/Limit"
       - $ref: "searchParameters.yaml#/PageToken"
     responses:

--- a/paths/placements.yaml
+++ b/paths/placements.yaml
@@ -78,8 +78,6 @@ placements:
             - EndDateAsc
             - EndDateDesc
             - ModifiedDesc
-          default: ModifiedDesc
-
       - $ref: "searchParameters.yaml#/PageToken"
       - $ref: "searchParameters.yaml#/Limit"
 

--- a/paths/programmes.yaml
+++ b/paths/programmes.yaml
@@ -36,8 +36,6 @@ programmes:
             - NameAsc
             - CodeAsc
             - ModifiedDesc
-          default: ModifiedDesc
-
       - $ref: "searchParameters.yaml#/Limit"
       - $ref: "searchParameters.yaml#/PageToken"
     responses:

--- a/paths/searchParameters.yaml
+++ b/paths/searchParameters.yaml
@@ -51,9 +51,8 @@ Sortkey:
   schema:
     type: string
     enum:
-      - DisplayNameAsc
       - ModifiedDesc
-    default: ModifiedDesc
+      - DisplayNameAsc
 
 Offset:
   in: query

--- a/paths/studyPlans.yaml
+++ b/paths/studyPlans.yaml
@@ -60,8 +60,6 @@ studyPlans:
             - StartDateDesc
             - EndDateAsc
             - EndDateDesc
-          default: ModifiedDesc
-
       - $ref: "searchParameters.yaml#/Limit"
       - $ref: "searchParameters.yaml#/PageToken"
     responses:

--- a/paths/syllabuses.yaml
+++ b/paths/syllabuses.yaml
@@ -26,8 +26,6 @@ syllabuses:
             - CourseCodeDesc
             - SubjectDesignationAsc
             - SubjectDesignationDesc
-          default: ModifiedDesc
-
       - $ref: "searchParameters.yaml#/Limit"
       - $ref: "searchParameters.yaml#/PageToken"
     responses:


### PR DESCRIPTION
If the consumer doesn't care about sort order it's better that it can be unspecified so that the server can return the  elements in the order that it most efficient. 