### PR TITLE
fix typo in Grade.diplomaProject.titleEnglish

### DIFF
--- a/Grade.yaml
+++ b/Grade.yaml
@@ -83,7 +83,7 @@ Grade:
         description:
           type: string
           description: Beskrivning av gymnasiearbete.
-        titleEngish:
+        titleEnglish:
           type: string
           description: Eventuell engelsk titel på gymnasiearbete.
         descriptionEnglish:


### PR DESCRIPTION
Ett litet stavfel som skulle behöva fixas på Grade.diplomaProject.