### PR TITLE
Added flag for secondary enrolment

### DIFF
--- a/Enrolment.yaml
+++ b/Enrolment.yaml
@@ -28,6 +28,9 @@ Enrolment:
     cancelled:
       type: boolean
       description: Inskrivningen har avbrutits i förväg.
+    secondary:
+      type: boolean
+      description: Inskrivningen är en sekundärinskrivning och speglar inte elevens huvudsakliga inskrivning.
     educationCode:
       type: string
       description: Studievägskod för den aktuella inskrivningen.


### PR DESCRIPTION
Suggestion to added information to enrolment to be able to distinguish secondary enrolments from primary ones. A secondary enrolment is defined as an enrolment at a school unit where the student does not have its primary enrolment. It can be used for students that are temporarily offered education at a different school unit.